### PR TITLE
Rework Data Nodes

### DIFF
--- a/ARC specification.md
+++ b/ARC specification.md
@@ -245,19 +245,21 @@ All metadata references to files or directories located inside the ARC MUST foll
 
 #### Examples
 
-In this example, there are two `assays`, with `Assay1`containing a measurement of a `Source` material, producing an output `Raw Data file`. `Assay2` references this `Data file` for producing a new `Derived Data File`
+##### General Pattern
+
+In this example, there are two `assays`, with `Assay1`containing a measurement of a `Source` material, producing an output `Data`. `Assay2` references this `Data` for producing a new `Data`.
 
 Use of `general pattern` relative paths from the arc root folder:
 
 `assays/Assay1/isa.assay.xlsx`:
 
-| Input [Source Name] | Parameter[Instrument model]          | Output [Raw Data File] | 
+| Input [Source Name] | Parameter[Instrument model]          | Output [Data] | 
 |-------------|---------------------------------|----------------------------------|
 | input       | Bruker 500 Avance | assays/Assay1/dataset/measurement.txt |
 
 `assays/Assay2/isa.assay.xlsx`:
 
-| Input [Raw Data File] | Parameter[script file]          | Output [Derived Data File] |
+| Input [Data] | Parameter[script file]          | Output [Data] |
 |----------------------------------|---------------------------------|----------------------------------|
 | assays/Assay1/dataset/measurement.txt | assays/Assay2/dataset/script.sh | assays/Assay2/dataset/result.txt |
 

--- a/ISA-XLSX.md
+++ b/ISA-XLSX.md
@@ -629,7 +629,7 @@ The `Data` node type MUST correspond to a relevant data resource location, follo
 The format of the data resource MAY be further qualified using a `Data Format` column. The `Data Format` SHOULD be expressed using a [MIME format](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types), most commonly consisting of two parts: a type and a subtype, separated by a slash (/) — with no whitespace between: `type/subtype`. If appropriate, a format from the list composed by [IANA](https://www.iana.org/assignments/media-types/media-types.xhtml)
 SHOULD be picked. Unregistered or niche encoding and file formats MAY be indicated instead via the most appropriate URL.
 
-The format and usage info about the Selector MAY be further qualified using a `Data Selector` column. The `Data Selector` SHOULD point to a web resource containing instructions about how the Selector is formatted and how it should be interpreted.
+The format and usage info about the Selector MAY be further qualified using a `Data Selector Format` column. The `Data Selector Format` SHOULD point to a web resource containing instructions about how the Selector is formatted and how it should be interpreted.
 
 
 ## Examples
@@ -639,7 +639,7 @@ The format and usage info about the Selector MAY be further qualified using a `D
 In this example, there is a measurement of two `Samples`, namely `input1` and `input2`. The values measured are both written into the same data resource in the location `result.csv`, whichs formatting is tabular, according to the `Data Format` being `text/csv`. To distinguish between the measurement values stemming from the different inputs, selectors were added to the resource location (seperated by a `#`), namely `col=1` and `col=2`. The specification about the formatting of these selectors can be found in the provided link, namely `https://datatracker.ietf.org/`.
 
 
-| Input [Sample Name] | Output [Data]          | Data Format | Data Selector | 
+| Input [Sample Name] | Output [Data]          | Data Format | Data Selector Format | 
 |-------------|---------------------------------|----------------------------------|--|
 | input1       | result.csv#col=1 | text/csv | https://datatracker.ietf.org/doc/html/rfc7111 |
 | input2       | result.csv#col=2 | text/csv | https://datatracker.ietf.org/doc/html/rfc7111 |

--- a/ISA-XLSX.md
+++ b/ISA-XLSX.md
@@ -624,10 +624,14 @@ Each annotation table sheet MUST contain at most one `Input` and at most one `Ou
 
 `Source Names`, `Sample Names`, `Material Names` MUST be unique across an ARC. If two of these entities with the same name exist in the same ARC, they are considered the same entity.
 
-The `Data` node type MUST correspond to a relevant data resource location, following the [Data Path Annotation](/ARC%20specification.md#data-path-annotation) patterns. If the annotation of the `Data` node refers not to the complete resource, but a part of it, a `Selector` MAY added. This Selector MUST be separated from the location using a `#`— with no whitespace between: `location#selector`. 
+The `Data` node type MUST correspond to a relevant data resource location, following the [Data Path Annotation](/ARC%20specification.md#data-path-annotation) patterns. If the annotation of the `Data` node refers not to the complete resource, but a part of it, a `Selector` MAY be added. This Selector MUST be separated from the resource location using a `#`— with no whitespace between: `location#selector`. If appropriate, the Selector SHOULD be formatted according to IRI fragment selectors specified by [W3](https://www.w3.org/TR/annotation-model/#fragment-selector).
 
-`Data Format` SHOULD be expressed using a [MIME format](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types), most commonly consisting of two parts: a type and a subtype, separated by a slash (/) — with no whitespace between: `type/subtype`. If appropriate, a format from the list composed by [IANA](https://www.iana.org/assignments/media-types/media-types.xhtml)
+The format of the data resource MAY be further qualified using a `Data Format` column. The `Data Format` SHOULD be expressed using a [MIME format](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types), most commonly consisting of two parts: a type and a subtype, separated by a slash (/) — with no whitespace between: `type/subtype`. If appropriate, a format from the list composed by [IANA](https://www.iana.org/assignments/media-types/media-types.xhtml)
 SHOULD be picked. Unregistered or niche encoding and file formats MAY be indicated instead via the most appropriate URL.
+
+The format and usage info about the selector MAY be further qualified using a `Data Selector` column. The `Data Selector` SHOULD point to a web resource containing instructions about how the selector is formatted and how it should be interpreted.
+
+
 
 ## Examples
 
@@ -637,7 +641,7 @@ Use of `general pattern` relative paths from the arc root folder:
 
 `assays/Assay1/isa.assay.xlsx`:
 
-| Input [Sample Name] | Output [Data]          | Output Data Format | Output Data Selector | 
+| Input [Sample Name] | Output [Data]          | Data Format | Data Selector | 
 |-------------|---------------------------------|----------------------------------|--|
 | input1       | result.csv#col=1 | text/csv | https://datatracker.ietf.org/doc/html/rfc7111 |
 | input2       | result.csv#col=2 | text/csv | https://datatracker.ietf.org/doc/html/rfc7111 |

--- a/ISA-XLSX.md
+++ b/ISA-XLSX.md
@@ -620,15 +620,27 @@ Each annotation table sheet MUST contain at most one `Input` and at most one `Ou
 
 - An `Extract Material` MUST be indicated with the node type `Material Name`.
 
-- An `Image File` MUST be indicated with the node type `Image File`.
-
-- A `Raw Data File` MUST be indicated with the node type `Raw Data File`.
-
-- A `Derived Data File` MUST be indicated with the node type `Derived Data File`.
+- A `Data` object MUST be indicated with the node type `Data`.
 
 `Source Names`, `Sample Names`, `Material Names` MUST be unique across an ARC. If two of these entities with the same name exist in the same ARC, they are considered the same entity.
 
-`Image File`, `Raw Data File` or `Derived Data File` node types MUST correspond to a relevant file location, following the [Data Path Annotation](/ARC%20specification.md#data-path-annotation) patterns.
+The `Data` node type MUST correspond to a relevant data resource location, following the [Data Path Annotation](/ARC%20specification.md#data-path-annotation) patterns. If the annotation of the `Data` node refers not to the complete resource, but a part of it, a `Selector` MAY added. This Selector MUST be separated from the location using a `#`— with no whitespace between: `location#selector`. 
+
+`Data Format` SHOULD be expressed using a [MIME format](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types), most commonly consisting of two parts: a type and a subtype, separated by a slash (/) — with no whitespace between: `type/subtype`. If appropriate, a format from the list composed by [IANA](https://www.iana.org/assignments/media-types/media-types.xhtml)
+SHOULD be picked. Unregistered or niche encoding and file formats MAY be indicated instead via the most appropriate URL.
+
+## Examples
+
+In this example, there are two `assays`, with `Assay1`containing a measurement of a `Source` material, producing an output `Raw Data file`. `Assay2` references this `Data file` for producing a new `Derived Data File`
+
+Use of `general pattern` relative paths from the arc root folder:
+
+`assays/Assay1/isa.assay.xlsx`:
+
+| Input [Sample Name] | Output [Data]          | Output Data Format | Output Data Selector | 
+|-------------|---------------------------------|----------------------------------|--|
+| input1       | result.csv#col=1 | text/csv | https://datatracker.ietf.org/doc/html/rfc7111 |
+| input2       | result.csv#col=2 | text/csv | https://datatracker.ietf.org/doc/html/rfc7111 |
 
 ## Protocol Columns
 

--- a/ISA-XLSX.md
+++ b/ISA-XLSX.md
@@ -629,17 +629,15 @@ The `Data` node type MUST correspond to a relevant data resource location, follo
 The format of the data resource MAY be further qualified using a `Data Format` column. The `Data Format` SHOULD be expressed using a [MIME format](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types), most commonly consisting of two parts: a type and a subtype, separated by a slash (/) — with no whitespace between: `type/subtype`. If appropriate, a format from the list composed by [IANA](https://www.iana.org/assignments/media-types/media-types.xhtml)
 SHOULD be picked. Unregistered or niche encoding and file formats MAY be indicated instead via the most appropriate URL.
 
-The format and usage info about the selector MAY be further qualified using a `Data Selector` column. The `Data Selector` SHOULD point to a web resource containing instructions about how the selector is formatted and how it should be interpreted.
-
+The format and usage info about the Selector MAY be further qualified using a `Data Selector` column. The `Data Selector` SHOULD point to a web resource containing instructions about how the Selector is formatted and how it should be interpreted.
 
 
 ## Examples
 
-In this example, there are two `assays`, with `Assay1`containing a measurement of a `Source` material, producing an output `Raw Data file`. `Assay2` references this `Data file` for producing a new `Derived Data File`
+### Data Location and Selector
 
-Use of `general pattern` relative paths from the arc root folder:
+In this example, there is a measurement of two `Samples`, namely `input1` and `input2`. The values measured are both written into the same data resource in the location `result.csv`, whichs formatting is tabular, according to the `Data Format` being `text/csv`. To distinguish between the measurement values stemming from the different inputs, selectors were added to the resource location (seperated by a `#`), namely `col=1` and `col=2`. The specification about the formatting of these selectors can be found in the provided link, namely `https://datatracker.ietf.org/`.
 
-`assays/Assay1/isa.assay.xlsx`:
 
 | Input [Sample Name] | Output [Data]          | Data Format | Data Selector | 
 |-------------|---------------------------------|----------------------------------|--|


### PR DESCRIPTION
# Data Selectors

This PR includes the specification for annotating not only full data resources, but parts of it. For this, after specifying the `resource location`, a `selector` can be appended, separated by a `#`.

This design is heavily inspired by data [fragment selectors](https://www.w3.org/TR/annotation-model/#fragment-selector) that can be found in URLs and has two-fold advantage over the solution proposed in https://github.com/nfdi4plants/ARC-specification/issues/80#issuecomment-1838631486, where the selector is moved into another column:

1. In standard cases, a single column suffices, making the information more compact (and e.g. more easily copyable)
2. This more closely resembles URIs, potentially being more intuitive for data annotation experts

To support non-standard cases and increase verbosity, two qualifying columns were added, closely following the proposal made by @stain in https://github.com/ISA-tools/isa-specs/pull/15#issuecomment-1462529547. This goes in line with [Schema.org/CreativeWork](https://schema.org/CreativeWork) and by this I hope to increase compatiblity with RO-Crate.

# Data Category annotation

Additionally, for specifying the `Input` and `Output` of an annotation table, I cut out all distinctions about the content of the `Data` resource (`Raw Data File`, `Derived Data File` and `Image File`). This is in line with many discussion about this topic, with the conclusion that this distinction is kind of artificial. I also went against `Data File` and `Data Directory` as again, this distinction tries to increase information, but by design excludes cases that do not fall under these categories. 


Any input would be welcome
@kappe-c @chgarth @muehlhaus @Brilator 

