### PR TITLE
Add validation_summary.json specs, package metadata, and ARC apps

### DIFF
--- a/ARC specification.md
+++ b/ARC specification.md
@@ -598,7 +598,7 @@ sequenceDiagram
     DataHUB ->> DataHUB : trigger validation for commit
     DataHUB ->> ARC : commit validation results <br> to cqc branch
     DataHUB ->> ARC : create badge
-    Note over User, ARC App: QCQ Hooks
+    Note over User, ARC App: CQC Hooks
     User ->> ARC App : click on badge link
     DataHUB ->> ARC App : trigger some action based on validation results
     ARC App ->> DataHUB : Request relevant information


### PR DESCRIPTION
This PR intends to

- specify the new, third output file of validation packages _validation_summary.json_
- specify a minimal set of validation package metadata 
- introduce the concept of _ARC apps_ - services that can be triggered based on the results of a validation package
- include a full example of the (intended/conceptual) CQC setup in our DataHUB as a reference

cc @HLWeil @Brilator 

I included the reference example as a sequence diagram, if that is not allowed i think i would rather not include it, because that would be very convoluted in text form.

closes #106 
closes #107 
closes #103 